### PR TITLE
Make import compatible with python 3.

### DIFF
--- a/jsonp2json/__init__.py
+++ b/jsonp2json/__init__.py
@@ -1,1 +1,1 @@
-from jsonp2json import convert
+from .jsonp2json import convert


### PR DESCRIPTION
Before: 
```
python3
Python 3.6.3 (default, Oct 24 2017, 14:48:20) 
[GCC 7.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import jsonp2json
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3.6/site-packages/jsonp2json/__init__.py", line 1, in <module>
    from jsonp2json import convert
ImportError: cannot import name 'convert'
```